### PR TITLE
只对长标题启用特效

### DIFF
--- a/static/js/article-titles.js
+++ b/static/js/article-titles.js
@@ -13,6 +13,11 @@ function title_effect(el) {
   var cln = el.cloneNode(true);
   cln.className = "full-title";
   el.parentNode.appendChild(cln);
+  var comp_style = window.getComputedStyle(cln, null);
+  var ht = parseFloat(comp_style.getPropertyValue("height"));
+  var lht = parseFloat(comp_style.getPropertyValue("line-height"));
+  // Only enable title effect for multi-line titles
+  if (ht < 1.5 * lht)  el.parentNode.removeChild(cln);
 }
 
 // Find all titles

--- a/static/js/article-titles.js
+++ b/static/js/article-titles.js
@@ -15,7 +15,7 @@ function title_effect(el) {
   el.parentNode.appendChild(cln);
 }
 
-// Find all iframes
+// Find all titles
 var titles = document.querySelectorAll(".article-list h1"), len = titles.length;
 for (var i = 0; i < len; i++) {
   title_effect(titles[i]);


### PR DESCRIPTION
参见 #611 。思路是对比元素的 `height` 和 `line-height`，如果 `height` 较大，说明有多行。