### PR TITLE
add members based on authors

### DIFF
--- a/data/members.yaml
+++ b/data/members.yaml
@@ -42,7 +42,8 @@ list:
     image: https://cloud.githubusercontent.com/assets/7221728/26047173/a982236e-3984-11e7-9065-2baac85fccf4.png
     intro: 统计之都理事会主席，江西财经大学金融管理国际研究院助理教授，澳大利亚国立大学2011级统计学博士，中国人民大学2009级统计学硕士，中南财经政法大学2005级统计学&法学学士。2007年初识统计之都，常年潜水于COS论坛，并迅速成为COS迷粉，追随多年。2014年于南通婚礼偶遇太云，相逢恨晚，当即遁入COS门。现在在COS编辑部主要负责端茶送水，跑腿打杂，偶尔审审文章。
   - name: 高涛
-    intro: 博客：<http://joegaotao.github.io/cn/>。
+    image: https://user-images.githubusercontent.com/1142836/28492456-ea8789ca-6f36-11e7-8b47-91eada415a4c.jpg
+    intro: 高涛，中国人民大学2012级数理统计研究生，2009年在太云带领下加入COS，给COS编辑部和R会议打杂，参与《R语言实战》《ggplot2：数据分析与图形艺术》书籍翻译。对统计机器学习、优化算法、时序预测感兴趣，之前混迹于互联网圈，现就职上海明汯投资做量化。博客：<http://joegaotao.github.io/>。
   - name: 何通
     image: https://avatars2.githubusercontent.com/u/1289856
     intro: 何通，中山大学统计系本科，Simon Fraser University数据挖掘研究生，R包xgboost作者。现任Fortinet软件工程师。

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -91,7 +91,8 @@ list:
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro:  毕业于北京大学光华管理学院商务统计系，女博士一枚<br/>师从王汉生教授，狗熊会熊孩子一只<br/>现任职于中央财经大学统计与数学学院，年轻讲师一个<br/>在理论研究方面，关注高维数据和社交网络数据，在JASA和Annals上均有发表<br/>在业界实践方面，关注车联网行业的数据分析
   - name: 唐源
-    intro: 目前就职于芝加哥一家创业公司，曾参与和创作过多个被广泛使用的R和Python开源项目，是ggfortify，lfda，metric-learn等包的作者，也是 xgboost，caret，pandas等包的贡献者。（喜欢爬山和烧烤）
+    image: https://terrytangyuan.github.io/img/final_prof_pic_2.png
+    intro: 《TensorFlow实战》作者，目前在芝加哥的Uptake公司带领团队建立用于多个物联网垂直领域的条件和健康监控数据科学引擎，也建立了公司的预测模型引擎，现在被用于航空、能源等大型机械领域。一直活跃在开源软件社区，是TensorFlow和DMLC的成员，是TensorFlow、XGBoost、MXNet等软件的committer，ggfortify、reticulate等软件的作者，以及caret、pandas等软件的贡献者。曾获得谷歌Open Source Peer Bonus，以及多项高校和企业编程竞赛的奖项。在美国宾州州立大学获得荣誉数学学位，曾在本科学习期间成为创业公司DataNovo的核心创始成员，研究专利数据挖掘、无关键字现有技术搜索、策略推荐等。个人主页：<https://terrytangyuan.github.io/about/>
   - name: 王佳
     image: https://cloud.githubusercontent.com/assets/7221728/25832304/50a0da66-349c-11e7-9ead-70091ddd1dd7.jpg
     intro: 人大统计硕士在读，R与SAS爱好者，写得了代码，做得了调查，温柔靠谱的双鱼座妹子。能和cos聪明有趣的小编们一起工作玩耍是非常过瘾的经历

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -117,6 +117,8 @@ list:
   - name: 谢益辉
     image: https://user-images.githubusercontent.com/163582/28285860-d3c70c72-6afb-11e7-9a92-71d9575188b5.png
     intro: 中国人民大学统计硕士，爱荷华州立大学统计学博士，R 包 [knitr](https://yihui.name/knitr/) 的主要作者。现为 RStudio 软件工程师，曾负责 Shiny 包相关开发工作，后转入 R Markdown 相关扩展包的开发，包括 [bookdown](https://github.com/rstudio/bookdown) 和 [blogdown](https://github.com/rstudio/blogdown)。对统计计算、可视化、以及各类网页相关技术感兴趣，有志于对技术写作工具做减法工作，坚信人类浪费了太多时间在期刊论文、学位论文、书籍的排版上。平时主要活跃在 [Github](https://github.com/yihui) 上。个人主页在 <https://yihui.name>，思想偏激，流水账、意识流甚多，小人之心甚重，慎入。
+  - name: 熊熹
+    intro: 女，人称“师姐”。
   - name: 徐浩
     image: https://cloud.githubusercontent.com/assets/7221728/25791994/77d093e8-33f6-11e7-9990-3d4436146817.jpg
     intro: JD Power的数据分析师。

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -103,6 +103,8 @@ list:
   - name: 王毅然
     image: https://cloud.githubusercontent.com/assets/7221728/25788597/e295b736-33dc-11e7-9e62-61ea8f0190b1.jpg
     intro: 中国人民大学2013级经济学与数学（双学位）实验班本科生，美国北卡罗莱纳州立大学2017级统计学PhD。新人一枚，2017年5月刚刚加入统计之都，希望以后可以为统计之都贡献更多自己的力量。
+  - name: "Earo Wang"
+    intro: [Earo Wang](https://earo.me/), Ph.D. student at Monash University. 
   - name: 汪张扬
     image: https://uploads.cosx.org/2016/06/tutu.jpeg
     intro: 汪张扬，男，1991年出生；2012年中国科学技术大学电子通信工程本科毕业；2016年伊利诺伊大学香槟分校电子计算机工程博士毕业；2016年加入德州A&M大学计算机科学系任助理教授。更多信息见[个人主页](http://www.atlaswang.com)。

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -104,7 +104,7 @@ list:
     image: https://cloud.githubusercontent.com/assets/7221728/25788597/e295b736-33dc-11e7-9e62-61ea8f0190b1.jpg
     intro: 中国人民大学2013级经济学与数学（双学位）实验班本科生，美国北卡罗莱纳州立大学2017级统计学PhD。新人一枚，2017年5月刚刚加入统计之都，希望以后可以为统计之都贡献更多自己的力量。
   - name: "Earo Wang"
-    intro: [Earo Wang](https://earo.me/), Ph.D. student at Monash University. 
+    intro: "[Earo Wang](https://earo.me/), Ph.D. student at Monash University."
   - name: 汪张扬
     image: https://uploads.cosx.org/2016/06/tutu.jpeg
     intro: 汪张扬，男，1991年出生；2012年中国科学技术大学电子通信工程本科毕业；2016年伊利诺伊大学香槟分校电子计算机工程博士毕业；2016年加入德州A&M大学计算机科学系任助理教授。更多信息见[个人主页](http://www.atlaswang.com)。
@@ -137,7 +137,7 @@ list:
     image: https://cloud.githubusercontent.com/assets/7221728/25788531/67c2c7d8-33dc-11e7-8bc5-894640e04688.jpg
     intro: 硕士生，目前就读于中央财经大学应用统计专业，尤爱美食和旅行。10%的理科生，编程很鶸，轻度R语言使用者。90%的文科生，爱读书，爱写作，爱硬笔书法，爱PPT的设计与制作。一大波技能正等着我去学习……
   - name: 郁彬
-    intro: [郁彬](http://www.stat.berkeley.edu/~binyu/Site/Welcome.html)，1980年进入北京大学数学系攻读本科，1985年获陈省身数学交流项目资助前往美国，于1987年和1990年分别获伯克利大学统计学硕士和博士学位。她曾在威斯康星大学麦迪逊分校和耶鲁大学任教，并且在贝尔实验室工作。2006年，郁彬院友获得古根海姆奖。2009年到2012年间，她担任加州大学伯克利分校统计系系主任，现在则是伯克利分校统计系和电子工程与计算机科学系终身教授。2013年，郁彬院友当选美国艺术与科学学院院士，2014年当选美国国家科学院院士，此外，她还是北大微软统计和信息技术实验室的创办者和主任之一。
+    intro: "[郁彬](http://www.stat.berkeley.edu/~binyu/Site/Welcome.html)，1980年进入北京大学数学系攻读本科，1985年获陈省身数学交流项目资助前往美国，于1987年和1990年分别获伯克利大学统计学硕士和博士学位。她曾在威斯康星大学麦迪逊分校和耶鲁大学任教，并且在贝尔实验室工作。2006年，郁彬院友获得古根海姆奖。2009年到2012年间，她担任加州大学伯克利分校统计系系主任，现在则是伯克利分校统计系和电子工程与计算机科学系终身教授。2013年，郁彬院友当选美国艺术与科学学院院士，2014年当选美国国家科学院院士，此外，她还是北大微软统计和信息技术实验室的创办者和主任之一。"
   - name: 余光创
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro: 余光创，香港大学公共卫生学院，生物信息学博士生。博客：<https://guangchuangyu.github.io>， 公众号：biobabble

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -26,15 +26,23 @@ list:
   - name: 邓金涛
     image: https://cloud.githubusercontent.com/assets/7221728/25788559/9a1f0282-33dc-11e7-9f63-10a7ac42c4f9.jpg
     intro: 男，中国人民大学2014级统计学院学渣一枚，出于莫名的原因大家都叫我“小王子”。 兴趣爱好还算广泛，篮球打得还过得去，钢琴弹得也还马虎。当初由于担任宣传部部长等机缘巧合进入了统计之都大家庭。不过自从本人大三在宣传部卸任后，业务技术早已被抛到九霄云外，因而硬着头皮怒怼出的东西常被云伯，秋思等人吐槽，实在有愧于江东父老。
+  - name: 邓一硕
+    intro: 毕业于中央财经大学，感兴趣领域是数据挖掘技术（R语言）在金融投资分析和计量经济学中的应用。博客：<http://yishuo.org>；微博：<http://weibo.com/dengyishuo>。
   - name: 范超
     image: https://cloud.githubusercontent.com/assets/7221728/25791993/7581204e-33f6-11e7-9095-e7a6f7dc0e6c.jpg
     intro: 江湖代号小妹，混迹于人大统计学院，崇尚数据分析的快乐， 希望和志同道合的童鞋一起学习成长～
+  - name: 冯国双
+    intro: 毕业于北京大学医学部，流行病与卫生统计学专业博士。现工作于中国疾病预防控制中心，负责中国疾控中心研究生和博士生的统计学教学工作。主要擅长各种回归分析、非独立数据分析、药物分析建模、新药临床试验中数据管理与统计分析、试验设计分析等。熟悉SAS软件的操作与应用，主编SAS专著2部：《医学案例统计分析与SAS应用》，《医学研究中的logistic回归分析及SAS实现》。现任“北京市免疫规划和疫苗评价专家委员会”专家委员、《中华护理学杂志》、《中国性病艾滋病学杂志》审稿专家，《慢性病学杂志》编委。博客：[“卫生统计空间”](http://hi.baidu.com/healthstat)
   - name: 冯璟烁
     image: https://cloud.githubusercontent.com/assets/7221728/25802086/6784d95e-3423-11e7-9bd5-f58775b4e3d7.jpg
     intro: 中国人民大学统计学院应用统计学2017届本科生，华盛顿大学工业工程系2017级在读博士。2015年加入统计之都，曾多次在各R会组委会中露脸，专职画画，兼职办会。目前是COS编辑部小编一枚。
+  - name: 冯俊晨
+    intro: http://www.fengjunchen.com
   - name: 冯凌秉
     image: https://cloud.githubusercontent.com/assets/7221728/26047173/a982236e-3984-11e7-9065-2baac85fccf4.png
     intro: 统计之都理事会主席，江西财经大学金融管理国际研究院助理教授，澳大利亚国立大学2011级统计学博士，中国人民大学2009级统计学硕士，中南财经政法大学2005级统计学&法学学士。2007年初识统计之都，常年潜水于COS论坛，并迅速成为COS迷粉，追随多年。2014年于南通婚礼偶遇太云，相逢恨晚，当即遁入COS门。现在在COS编辑部主要负责端茶送水，跑腿打杂，偶尔审审文章。
+  - name: 高涛
+    intro: 博客：<http://joegaotao.github.io/cn/>。
   - name: 何通
     image: https://avatars2.githubusercontent.com/u/1289856
     intro: 何通，中山大学统计系本科，Simon Fraser University数据挖掘研究生，R包xgboost作者。现任Fortinet软件工程师。
@@ -59,6 +67,10 @@ list:
   - name: 李宇轩
     image: https://cloud.githubusercontent.com/assets/7221728/25788586/d81c09ae-33dc-11e7-8580-05ab733a7c73.jpg
     intro: 人大统院本科生，爱看书（从小喜欢），爱音乐（多听不多唱）、爱运动（玩和看都爱），很喜欢旅游（尤其一人游），虽然现在还是一只小本科僧，但相信自己会有用武之地，不达目的绝不放弃。
+  - name: 林荟
+    intro: 女，杜邦先锋总部市场部统计师，毕业于 Iowa State University 统计系，生年不详卒年尚无法预测。
+  - name: 刘辰昂
+    intro: "浙大准大四本科，统计之都主站编辑。weibo：[求证1加1](http://weibo.com/2011764505/profile)；blog: <http://chenangliu.info/cn/>；email: liuchenang@gmail.com"
   - name: 刘跃文
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro: 香港城市大学及中国科学技术大学博士<br/>前鹅厂数据研究员<br/>商科小讲师一枚，努力写论文中<br/>玩数据分析、玩社交网络<br/>梦想着讲有趣的故事，做有价值的研究<br/>讲授信息技术管理、数据库与数据管理、数据挖掘与知识发现等课程<br/>段子手
@@ -77,6 +89,8 @@ list:
   - name: 水妈
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro:  毕业于北京大学光华管理学院商务统计系，女博士一枚<br/>师从王汉生教授，狗熊会熊孩子一只<br/>现任职于中央财经大学统计与数学学院，年轻讲师一个<br/>在理论研究方面，关注高维数据和社交网络数据，在JASA和Annals上均有发表<br/>在业界实践方面，关注车联网行业的数据分析
+  - name: 唐源
+    intro: 目前就职于芝加哥一家创业公司，曾参与和创作过多个被广泛使用的R和Python开源项目，是ggfortify，lfda，metric-learn等包的作者，也是 xgboost，caret，pandas等包的贡献者。（喜欢爬山和烧烤）
   - name: 王佳
     image: https://cloud.githubusercontent.com/assets/7221728/25832304/50a0da66-349c-11e7-9ead-70091ddd1dd7.jpg
     intro: 人大统计硕士在读，R与SAS爱好者，写得了代码，做得了调查，温柔靠谱的双鱼座妹子。能和cos聪明有趣的小编们一起工作玩耍是非常过瘾的经历
@@ -92,6 +106,8 @@ list:
   - name: 汪张扬
     image: https://uploads.cosx.org/2016/06/tutu.jpeg
     intro: 汪张扬，男，1991年出生；2012年中国科学技术大学电子通信工程本科毕业；2016年伊利诺伊大学香槟分校电子计算机工程博士毕业；2016年加入德州A&M大学计算机科学系任助理教授。更多信息见[个人主页](http://www.atlaswang.com)。
+  - name: 魏太云
+    intro: <http://www.weibo.com/taiyun>
   - name: 肖凯
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro: 一个喜欢折腾数据的人，与李舰合著了《数据科学中的R语言》，现就职于蚂蚁金服。
@@ -116,9 +132,13 @@ list:
   - name: 翟晋
     image: https://cloud.githubusercontent.com/assets/7221728/25788531/67c2c7d8-33dc-11e7-8bc5-894640e04688.jpg
     intro: 硕士生，目前就读于中央财经大学应用统计专业，尤爱美食和旅行。10%的理科生，编程很鶸，轻度R语言使用者。90%的文科生，爱读书，爱写作，爱硬笔书法，爱PPT的设计与制作。一大波技能正等着我去学习……
+  - name: 郁彬
+    intro: http://www.stat.berkeley.edu/~binyu/Site/Welcome.html
   - name: 余光创
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro: 余光创，香港大学公共卫生学院，生物信息学博士生。博客：<https://guangchuangyu.github.io>， 公众号：biobabble
+  - name: 张驰原
+    intro: 英文名 pluskid，博客：<http://blog.pluskid.org>。
   - name: 张翔
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro: 车轮互联数据副总裁，COS9年老水友

--- a/data/members.yaml
+++ b/data/members.yaml
@@ -133,7 +133,7 @@ list:
     image: https://cloud.githubusercontent.com/assets/7221728/25788531/67c2c7d8-33dc-11e7-8bc5-894640e04688.jpg
     intro: 硕士生，目前就读于中央财经大学应用统计专业，尤爱美食和旅行。10%的理科生，编程很鶸，轻度R语言使用者。90%的文科生，爱读书，爱写作，爱硬笔书法，爱PPT的设计与制作。一大波技能正等着我去学习……
   - name: 郁彬
-    intro: http://www.stat.berkeley.edu/~binyu/Site/Welcome.html
+    intro: [郁彬](http://www.stat.berkeley.edu/~binyu/Site/Welcome.html)，1980年进入北京大学数学系攻读本科，1985年获陈省身数学交流项目资助前往美国，于1987年和1990年分别获伯克利大学统计学硕士和博士学位。她曾在威斯康星大学麦迪逊分校和耶鲁大学任教，并且在贝尔实验室工作。2006年，郁彬院友获得古根海姆奖。2009年到2012年间，她担任加州大学伯克利分校统计系系主任，现在则是伯克利分校统计系和电子工程与计算机科学系终身教授。2013年，郁彬院友当选美国艺术与科学学院院士，2014年当选美国国家科学院院士，此外，她还是北大微软统计和信息技术实验室的创办者和主任之一。
   - name: 余光创
     image: https://user-images.githubusercontent.com/7221728/28346855-21adbf2e-6c66-11e7-95d8-171b0fb51c6b.png
     intro: 余光创，香港大学公共卫生学院，生物信息学博士生。博客：<https://guangchuangyu.github.io>， 公众号：biobabble


### PR DESCRIPTION
https://github.com/cosname/cosx.org/issues/663
https://github.com/cosname/cosx.org/pull/669

在清理 author meta 时候，添加了一些作者简介。

记录：

1. 标准：明显是来自 COS 的，或者有交集的，比如说 yishuo、taiyun、pluskid、yubin ；转载稿里有作者简介的；多次投稿的（眼熟的），如唐源。
2. 采访稿里的受采访人**并没有**添加到此文件里；译稿里，原作者简介也**并没有**添加。
3. 全都没有图片。