### PR TITLE
fix possible typo

### DIFF
--- a/content/post/2013-09-17-causality8-smoke-and-lung-cancer.md
+++ b/content/post/2013-09-17-causality8-smoke-and-lung-cancer.md
@@ -13,7 +13,7 @@ tags:
   - 因果推断
   - 相对风险
   - 肺癌
-slug: casuality8-smoke-and-lung-cancer
+slug: causality8-smoke-and-lung-cancer
 forum_id: 418970
 ---
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -40,6 +40,7 @@ https://master--cosx.netlify.com/*   https://cosx.org/:splat  301!
 /2011/12/stories-about-statistical- /2011/12/stories-about-statistical-learning
 /2011/01/how-does-glm-generalize-lm-    /2011/01/how-does-glm-generalize-lm-assumption
 /2020/09/COVID-19-bulletin-board/ /2020/09/covid19-bulletin-board/
+/2013/09/casuality8-smoke-and-lung-cancer/  /2013/09/causality8-smoke-and-lung-cancer/
 
 /en/topic/*             /archives/
 


### PR DESCRIPTION
fix `casuality` -> `causality` in the title and slug, but concerned about these changes might make old references (if any) failed.
