### PR TITLE
 增加对 Google 版思源宋体（Noto Serif CJK SC）支持

### DIFF
--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -1,5 +1,5 @@
 body {
-  font-family: Optima, 'Lucida Sans', Calibri, Candara, Arial, 'source-han-serif-sc', 'Source Han Serif SC', 'Source Han Serif CN', 'Source Han Serif TC', 'Source Han Serif TW', 'Source Han Serif', 'Songti SC', 'Microsoft YaHei', sans-serif;
+  font-family: Optima, 'Lucida Sans', Calibri, Candara, Arial, 'source-han-serif-sc', 'Source Han Serif SC', 'Source Han Serif CN', 'Source Han Serif TC', 'Source Han Serif TW', 'Source Han Serif', 'Songti SC', 'Noto Serif CJK SC', 'Microsoft YaHei', sans-serif;
 }
 blockquote, .date-author {
   font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, 'STKaiti', 'KaiTi', '楷体', 'SimKai', 'DFKai-SB', 'NSimSun', serif;

--- a/static/js/center-img.js
+++ b/static/js/center-img.js
@@ -1,0 +1,30 @@
+(function() {
+  function center_el(tagName) {
+    var tags = document.getElementsByTagName(tagName), i, tag;
+    for (i = 0; i < tags.length; i++) {
+      tag = tags[i];
+      var parent = tag.parentElement;
+      // center an image if it is the only element of its parent
+      if (parent.childNodes.length === 1) {
+        // if there is a link on image, check grandparent
+        var parentA = parent.nodeName === 'A';
+        if (parentA) {
+          parent = parent.parentElement;
+          if (parent.childNodes.length != 1) continue;
+          parent.firstChild.style.border = 'none';
+        }
+        if (parent.nodeName === 'P') {
+          parent.style.textAlign = 'center';
+          if (!parentA && tagName === 'img') {
+            parent.innerHTML = '<a href="' + tag.src + '" style="border: none;">' +
+              tag.outerHTML + '</a>';
+          }
+        }
+      }
+    }
+  }
+  var tagNames = ['img', 'embed', 'object'];
+  for (var i = 0; i < tagNames.length; i++) {
+    center_el(tagNames[i]);
+  }
+})();

--- a/static/js/math-code.js
+++ b/static/js/math-code.js
@@ -1,0 +1,20 @@
+(function() {
+  var i, text, code, codes = document.getElementsByTagName('code');
+  for (i = 0; i < codes.length;) {
+    code = codes[i];
+    if (code.parentNode.tagName !== 'PRE' && code.childElementCount === 0) {
+      text = code.textContent;
+      if (/^\$[^$]/.test(text) && /[^$]\$$/.test(text)) {
+        text = text.replace(/^\$/, '\\(').replace(/\$$/, '\\)');
+        code.textContent = text;
+      }
+      if (/^\\\((.|\s)+\\\)$/.test(text) || /^\\\[(.|\s)+\\\]$/.test(text) ||
+          /^\$(.|\s)+\$$/.test(text) ||
+          /^\\begin\{([^}]+)\}(.|\s)+\\end\{[^}]+\}$/.test(text)) {
+        code.outerHTML = code.innerHTML;  // remove <code></code>
+        continue;
+      }
+    }
+    i++;
+  }
+})();


### PR DESCRIPTION

Ubuntu 系统上使用的是 Google 版思源宋体，而不是 Adobe 版的，名称有差异，导致 Ubuntu 系统下思源字体不能正常渲染。