### PR TITLE
文章目录结构从一级开始，深度最好不超过三级

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -76,3 +76,5 @@ footnotereturnlinkcontents = "↩"
       unsafe = true
     [markup.highlight]
       codeFences = false
+    [markup.tableOfContents]
+      startLevel = 1


### PR DESCRIPTION
想在 config.toml 文件里设置文章目录从一级开始，这样比较符合正常的认知，即

```
[markup]
    [markup.goldmark.renderer]
      unsafe = true
    [markup.highlight]
      codeFences = false
```

改为

```
[markup]
    [markup.goldmark.renderer]
      unsafe = true
    [markup.highlight]
      codeFences = false
    [markup.tableOfContents]
      startLevel = 1
```