### PR TITLE
将 Gitee 图片改为链接

### DIFF
--- a/content/post/2018-01-17-build-blog-with-blogdown-hugo-netlify-github.md
+++ b/content/post/2018-01-17-build-blog-with-blogdown-hugo-netlify-github.md
@@ -16,13 +16,13 @@ forum_id: 419792
 meta_extra: "编辑：钟浩光；审稿：何通、赵鹏"
 ---
 
-
+由于 [Gitee 图床失效](https://github.com/cosname/cosx.org/issues/1020)，本文的图片改为链接，请见谅。
 
 ## 目标
 
 用R语言的blogdown + hugo + netlify + github搭建静态博客系统，用rstudio**专注于写作**。
 
-![1-4swordsman](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-01-swordsman-800.png)
+[1-4swordsman](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-01-swordsman-800.png)
 
 ### 优点
 
@@ -55,17 +55,17 @@ windows下安装很简单，就不描述了。
 - Tools -> Global Options -> Sweave -> Typeset LaTex into PDF using:**XeLaTeX**
 	- 这个是生成PDF文件用的，中文用户最好选择XeLaTeX
 	
-![2-sweave](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-02-sweave.png)	
+[2-sweave](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-02-sweave.png)	
 	
 - Tools -> Global Options -> Git/SVN -> Git executable:
 	- 安装好git后，打开这里应该就可以看到git的路径了
 
-![2-git](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-02-git.png)	
+[2-git](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-02-git.png)	
 
 - Tools -> Global Options -> Packages -> CRAN mirror: 
 	- 建议选择一个距离你比较近的镜像，速度会快点。例如，国内用户可以选择一个 China 的镜像。
 
-![2-cran](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-02-cran.png)	
+[2-cran](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-02-cran.png)	
 
 ### 安装blogdown和hugo
 
@@ -132,7 +132,7 @@ ok，我们来到这里，暂时离开一下rstudio，我们去弄弄github。
 
 ### 用github创建repository
 
-![3-new-repo](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-03-new-repo.png)
+[3-new-repo](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-03-new-repo.png)
 
 如图所示填写好repository name、Description，默认选择Public，可以选择复选框Initialize this repository with a README，`add .gitignore`选择`R`吧，点击**Create repository**就可以创建好用于保存网站的repository。
 
@@ -177,7 +177,7 @@ public
 
 打开：`File -> New Project -> New Directory -> Website using blogdown`
 
-![4-init-blogdown](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-04-init-blogdown.png)
+[4-init-blogdown](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-04-init-blogdown.png)
 
 因为我们已经安装了hugo，所以去掉hugo选项，Yihui是建议用**hugo-xmin**主题开始我们的blogdown之旅的，所以这里就选择了hugo-xmin。点击`Create Project`创建项目。
 
@@ -199,7 +199,7 @@ git push -u origin master
 
 到这里，博客已经可以在本地运行，我们试试看吧，点击菜单`Help`下面的`Addins`，如下图所示：
 
-![6-Addins-serve-site](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-06-serve-site.png)
+[6-Addins-serve-site](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-06-serve-site.png)
 
 点击`Serve Site`，可能会提示安装几个包例如shiny、miniUI等，点击yes安装就行了，其实点击这个跟在console里面输入`blogdown::serve_site()`是一样的，如果你还没有安装[**写轮眼xaringan**](https://github.com/yihui/xaringan)，会有下面的warning信息：
 
@@ -219,7 +219,7 @@ install.packages("xaringan")
 
 > Keep it simple, but not simpler
 
-![7-xmin](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-07-hugo-xmin.png)
+[7-xmin](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-07-hugo-xmin.png)
 
 我们也可以在浏览器输入`http://127.0.0.1:4321/`来浏览。
 
@@ -253,7 +253,7 @@ Yihui是这样说的：
 
 看看下面的pull request图：
 
-![8-1-pull-request](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-08-1-pull-request.png)
+[8-1-pull-request](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-08-1-pull-request.png)
 
 ## 设置netlify
 
@@ -266,11 +266,11 @@ Yihui是这样说的：
 
 登录进netlify后，点击导航栏`Sites`，再点击右上角`New site from Git`，再点击`Github`，如下图：
 
-![11-netlify-github](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-11-netlify-github.png)
+[11-netlify-github](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-11-netlify-github.png)
 
 然后按照下面的图填写就可以了：
 
-![12-deploy-site](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-12-deploy-site.png)
+[12-deploy-site](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-12-deploy-site.png)
 
 因为hugo生成的文件夹是`public`所以填public。
 
@@ -278,7 +278,7 @@ Yihui是这样说的：
 
 这个时候可以再去到一个叫`deploy settings`的地方（如下图所示），确保选项选中的是`none`，就是只deploy master分支。
 
-![13-deploy-settings](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-13-deploy-settings.png)
+[13-deploy-settings](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-13-deploy-settings.png)
 
 
 ### 设置个性二级域名
@@ -291,7 +291,7 @@ Yihui是这样说的：
 
 点击左边导航栏的`Domain management -> Domains`，
 
-![14-domains](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-14-domains.png)
+[14-domains](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-14-domains.png)
 
 然后点击`Add custom domain`，这个时候就可以输入你在域名提供商处注册的域名了。
 
@@ -299,11 +299,11 @@ Yihui是这样说的：
 
 添加域名后，点击如上图所示的小红点处，选择`Go to DNS panel`，然后就跳转到`DNS settings`页面，这里应该是不用做`Add new record`操作的（我忘记了，应该是自动添加了的），如果没有记录，就点它添加吧，如下图所示：
 
-![15-record-setting](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-15-record-setting.png)
+[15-record-setting](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-15-record-setting.png)
 
 上图的**Nameservers**部分有四条netlify的dns服务器域名，把他们添加到你注册域名的Nameservers就可以了，我在域名服务商里面的设置如下图所示：
 
-![16-nameservers-config](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-16-nameservers-config.png)
+[16-nameservers-config](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-16-nameservers-config.png)
 
 到此，所有的基本设置都已经完成。
 
@@ -311,7 +311,7 @@ Yihui是这样说的：
 
 前面提到我们可以专注于写作，现在所有东西都准备好，就可以把写好的文章update到线上，点击右上角`Git`标签，点击`commit`（如下图所示），填写好commit message点击`commit -> push`，这样就已经更新线上的博客，大概不用1分钟的时间，打开你的个人主页`www.domainname.com`就可以看到最新的文章出现了。
 
-![20180117-17-1-git-commit](https://gitee.com/heavenzone/picturebed/raw/master/zhonghaoguang.com/2018/20180117-17-1-git-commit.png)
+[20180117-17-1-git-commit](https://gitee.com/heavenzone/picturebed/blob/master/zhonghaoguang.com/2018/20180117-17-1-git-commit.png)
 
 至此，关于用R语言的blogdown + hugo + netlify + github搭建静态博客系统的介绍全部结束了，更多关于blogdown的魔法就等大家自己去挖掘了吧。
 

--- a/content/post/2021-03-07-build-blog-step-by-step.md
+++ b/content/post/2021-03-07-build-blog-step-by-step.md
@@ -9,6 +9,8 @@ slug: build-blog-step-by-step
 forum_id: 422996
 ---
 
+由于 [Gitee 图床失效](https://github.com/cosname/cosx.org/issues/1020)，本文的图片改为链接，请见谅。
+
 ## 简介
 
 你是不是特别想创建一个自己的私人博客？使用 `blogdown` 搭建博客难度大不大？与其他方式搭建博客相比又有什么优点？

--- a/content/post/2021-03-07-build-blog-step-by-step.md
+++ b/content/post/2021-03-07-build-blog-step-by-step.md
@@ -19,7 +19,7 @@ forum_id: 422996
 
 本文是作者在学习和使用中记录的一个详细笔记，主要参考：谢益辉的[《blogdown: Creating Websites with R Markdown》](https://bookdown.org/yihui/blogdown/ "《blogdown: Creating Websites with R Markdown》")，王诗翔的[B 站直播视频](<https://www.bilibili.com/video/BV13v41147BH?from=search&seid=3349593737199514913> " b 站直播视频")以及一些[ YouTube 视频教程](<https://www.youtube.com/watch?v=ox_Ue9yzf-0> " YouTube 视频教程")。
 
-![本文框架](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20211116131444590.png)
+[本文框架](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20211116131444590.png)
 
 ## 1. 入门教程
 
@@ -35,21 +35,21 @@ forum_id: 422996
 
 安装完后，新建一个新的 `Project（File - New project）`，然后选择 `New Directory`。鼠标滑到底部，找到 `Website using blogdown` 并点击进入。
 
-![创建新的项目](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719154631549.png)
+[创建新的项目](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719154631549.png)
 
 进入到以下界面（注意：**项目名称**建议使用英文，**目录**自行选择）。默认情况下 `Hugo theme` 是谢益辉的模板，这里将其进行拓展，使用了个人比较喜欢的主题：`Fastbyte01/KeepIt`，左下角勾选打开新的 session。
 
 > **注意**：为了保证整个演示流程的完整性，将“选择不同 Hugo 主题”教程放到文末作为附加内容。请注意整个演示逻辑，以免越学越糊涂。
 
-![新建界面时的设置](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719145109508.png)
+[新建界面时的设置](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719145109508.png)
 
 新建后界面如下，右下角给出了整个项目的文件。其中，圈起来的最为关键，稍后详细介绍。先编译这个初始 `blogdown`。
 
-![初始 blogdown](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719145533256.png)
+[初始 blogdown](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719145533256.png)
 
 选择 `Tool - addins`（Windows 更方便找到）然后选择以下按钮。
 
-![addins 插件](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719144620808.png)
+[addins 插件](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719144620808.png)
 
 稍等片刻，得到原始博客模板。
 
@@ -63,22 +63,22 @@ forum_id: 422996
 
 这里以该模板为例：主要修改 `config.yaml` 文件。首先将其打开，得到的界面如下：
 
-![`config.yaml` 文件](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719160220457.png)
+[`config.yaml` 文件](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719160220457.png)
 
 主要修改内容：`title`（第 4 行），`subtitle`（第 84 行）。保存该文件，右下角即可快速得到以下界面：
 
-![本地网站](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719160440312.png)
+[本地网站](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719160440312.png)
 
 如果想修改头像，可以在该 `yaml` 文件的第 34 行找到代码 `avatar: /images/me/avatar.jpeg`。此时从桌面打开该文件夹，更换该 JPEG 文件即可，例如：
 
-![修改头像](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719160756100.png)
+[修改头像](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719160756100.png)
 
 如果界面没有更新（可能是 Bug），可以运行代码，类似重启一下：
 
     blogdown::stop_server()
     blogdown:::serve_site()
 
-![修改后的 blog](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719161006304.png)
+[修改后的 blog](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719161006304.png)
 
 ### 1.4 将项目与 GitHub 相连
 
@@ -90,25 +90,25 @@ forum_id: 422996
 
     连接本地的文件夹（`zss`），按照下面操作。
 
-    ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719150226752.png)
+    [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719150226752.png)
 
     之后如果出现以下界面，点击蓝色字
 
-    ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719150332449.png)
+    [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719150332449.png)
 
     跳转到以下界面，设置线上 GitHub 对应仓库的相关信息。
 
-    ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719150402141.png)
+    [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719150402141.png)
 
     之后将创建好的仓库 publish 上去。`Keep this code private` 勾不勾都可以，勾选后仓库只能自己查看，不勾选取就将其变成公开的仓库。
 
-    ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719152432162.png)
+    [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719152432162.png)
 
 -   查看是否上传
 
     检查 GitHub 是否有这个仓库，如下：
 
-    ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719152558356.png)
+    [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719152558356.png)
 
     这时，本地项目和 GitHub 已经连接好啦！
 
@@ -121,31 +121,31 @@ forum_id: 422996
 
 首先是注册新用户（创建不难，如果进不去可能需要科学上网）。之后将其与 GitHub 相连接，进入以下界面：
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719150812523.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719150812523.png)
 
 点击  `New site from Git`，跟着步骤往下做。点击左下角的 Github，选择刚才创建的仓库（`zss`）。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719150849453.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719150849453.png)
 
 根据以下界面进行部署网站。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719151017788.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719151017788.png)
 
 等待部署，得到以下界面。注意，读者可以通过 `Site settings` 修改自己的网站名。你可以到 Porkbun 或 Namecheap 等网站购买专属域名。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719151045133.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719151045133.png)
 
 点击网站链接，即可得到私人网站啦！
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719151437396.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719151437396.png)
 
 > 恭喜你，你已经会简单创建自己的网站啦！
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719153023496.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719153023496.png)
 
-![白色版本](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719153323458.png)
+[白色版本](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719153323458.png)
 
-![黑色版本](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719153341901.png)
+[黑色版本](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719153341901.png)
 
 ## 2. 工作流
 
@@ -161,41 +161,41 @@ forum_id: 422996
 
 > **技巧**：直接打开桌面版本的 GitHub，找到对应的 Repository，按快捷键（红色框框给出了，`Show in Finder`）如下所示：
 
-![GitHub 桌面版本界面](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725171639643.png)
+[GitHub 桌面版本界面](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725171639643.png)
 
 > 当然，可以按快捷键直接进入网上的 Github 仓库。
 
 进入 RStudio 界面后，打开插件 addin。 mac 是在菜单栏 `Tools -> addins`中，Windows 直接在菜单栏就有一个小按钮 `addins`。选择下面红色框的内容，并点击执行（Execute）即可。
 
-![选中红色框，执行](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725171808872.png)
+[选中红色框，执行](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725171808872.png)
 
 > 或者直接在控制台输入代码也可以创建新的 Post（`blogdown::new_post()`）。建议在打开这个 Project 之后先把博客渲染出来（`blogdown::serve_site()`）。
 
 之后会跳转出一个框，根据所需填写！注意 Format 有三种形式。与 R 代码无关的可以直接创建 `.md` 文件，点击 Done 按钮，即可。
 
-![New Post 示例](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725172050133.png)
+[New Post 示例](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725172050133.png)
 
 ### 2.2 填写内容
 
 如果提前已经渲染了博客，右边的 Viewer 窗口就会自动同步所写内容。
 
-![开始内容输出！](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725194655246.png)
+[开始内容输出！](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725194655246.png)
 
 接下来，靠你自己啦！可以写一些读书笔记，科研想法等。小编这里给出前段时间写的一篇博客的内容作为示范。
 
-![填写内容](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725194617200.png)
+[填写内容](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725194617200.png)
 
 > **注意**：写好的 MD 文件可以直接将其导入。但是注意的是，图片等需要你手动添加到对应的目录下，或者使用图床进行线上存储，可以参考该篇[教程](https://mp.weixin.qq.com/s/djEicXPS-H-LTFNKDe26ig)。
 
 保存后，new post 就已经完成啦！
 
-![new post 完成](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725194742883.png)
+[new post 完成](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725194742883.png)
 
 ### 2.3 使用 GitHub 上传内容
 
 最后一步，将刚才修改过的内容，通过 GitHub 进行上传。操作流程如下，之后等几分钟，Netlify 网站知道你的该 GitHub 仓库内容出现变化后，会自动更新网站。
 
-![上传到 GitHub](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210725192651824.png)
+[上传到 GitHub](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210725192651824.png)
 
 这时一切完毕！恭喜你，已经掌握整个搭博客和写博客的流程啦！
 
@@ -203,15 +203,15 @@ forum_id: 422996
 
 [Hugo主题网站](https://hugothemesfree.com/ "Hugo主题网站")给出了很多免费试用的主题模板，读者可以选择个人偏好的主题（不需要和我上面一样），该网站的封面如下：
 
-![Hugo主题网站](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719163448115.png)
+[Hugo主题网站](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719163448115.png)
 
 本文使用示例为：[A simple but not simpler blog theme for Hugo](https://hugothemesfree.com/a-simple-but-not-simpler-blog-theme-for-hugo/ "A simple but not simpler blog theme for Hugo")，进入之后，点击 View GitHub 进入对应仓库。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719144857943.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719144857943.png)
 
 打开对应 GitHub 仓库后，复制名称到创建界面时的（Hugo theme）中。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210719145024762.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210719145024762.png)
 
 前面所述主题就是这样得到的。
 

--- a/content/post/2021-04-10-rmarkdown-introduction.md
+++ b/content/post/2021-04-10-rmarkdown-introduction.md
@@ -8,6 +8,8 @@ meta_extra: '审稿：黄湘云、任焱'
 slug: rmarkdown-introduction
 ---
 
+由于 [Gitee 图床失效](https://github.com/cosname/cosx.org/issues/1020)，本文的图片改为链接，请见谅。
+
 ## 第一章：R Markdown 简介  
 
 R Markdown 是 R 语言环境中提供的 markdown 编辑工具，运用 R Markdown 撰写文章，既可以像一般的 markdown 编辑器一样编辑文本，也可以在 R Markdown 中插入代码块，并将代码运行结果输出在 markdown 里。R Markdown 格式，简称为 Rmd 格式， 相应的源文件扩展名为 .Rmd。输出格式可以是 HTML、docx、pdf、beamer 等。

--- a/content/post/2021-04-10-rmarkdown-introduction.md
+++ b/content/post/2021-04-10-rmarkdown-introduction.md
@@ -24,7 +24,7 @@ R Markdown 是 R 语言环境中提供的 markdown 编辑工具，运用 R Markd
 
 视频已经非常清楚的介绍了 R Markdown 如何使用，内部构造、不同的输出类型，以及其他拓展（发布，与 github 相连）等。我们先对此进行简单了解即可，之后几期我会详细介绍。当然，官网也有一套 R Markdown 的入门教程，欢迎大家前去学习，官网截图如下：  
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424172657080.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424172657080.png)
 
 
 其他参考资料可见这一期推文：[R分享｜R Markdown参考资料分享和自制视频教程预告](http://mp.weixin.qq.com/s?__biz=MzI1NjUwMjQxMQ==&mid=2247490959&idx=1&sn=2374d35aa12a64bd00caea0bf424bbd0&chksm=ea24e26bdd536b7d2263b6e779a00f072f2e42f29346ab13a9ed4252144dc6d7e964c7ef7d52&scene=21#wechat_redirect)。关于 R Markdown 可参考专著([Xie, Allaire, and Grolemund 2019](https://www.math.pku.edu.cn/teachers/lidf/docs/Rbook/html/_Rbook/rmarkdown.html#ref-Xie2019:rmarkdown "Xie, Allaire, and Grolemund"))和([Xie, Dervieux, and Riederer 2020](https://www.math.pku.edu.cn/teachers/lidf/docs/Rbook/html/_Rbook/rmarkdown.html#ref-Xie2020:rmd-cook "Xie, Dervieux, and Riederer"))。 RStudio 网站提供了一个 R Markdown 使用小抄的下载链接：( rmarkdown-2.0.pdf )[rmarkdown-2.0.pdf]。 Pandoc 的文档见[Pandoc 网站](https://www.pandoc.org/ "pandoc 网站")，knitr 的详细文档参见网站[ knitr 文档](http://yihui.name/knitr/ "knitr 文档")。
@@ -65,15 +65,15 @@ TinyTeX 是一种轻便，可移植，跨平台，易于维护的 LaTeX 发行�
 
 1.  点击 RStudio 左上角的新建项目，选择 R Markdown 文件格式，即可建立一个 rmarkdown 编辑文件 。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424172842613.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424172842613.png)
 
 2.  在弹出的选项框里，可以申明 rmarkdown 的 Title、 Author 以及默认的输出文件格式，一般可以选择 HTML、PDF、Word 格式，具体见下图。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424172859520.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424172859520.png)
 
 3.  在新建的 markdown 文件里，主要包含三块内容：1. YAML、2. markdown 文本、3.代码块。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424172919598.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424172919598.png)
 
 **1）YAML**： R Markdown 的头部文件(上图1位置)， YAML 定义了 rmarkdwon 的性质，比如 title、author、date、 指定 output 文件类型等。
 
@@ -89,7 +89,7 @@ rmarkdown的导出方法有两种，一种是依靠 RStudio 手动导出，另�
 
 #### 手动导出
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424172937025.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424172937025.png)
 
 手动导出方法很简单，在完成 markdown 编辑后，手动点击上图红圈内 knit 按钮，选择导出格式类型即可， RStudio 支持导出 PDF、html、word 三种类型。
 
@@ -104,13 +104,13 @@ rmarkdown的导出方法有两种，一种是依靠 RStudio 手动导出，另�
 rmarkdown::render("test.Rmd")
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424173011826.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424173011826.png)
 
 ### 2.4. RStudio界面介绍
 
 若界面打开了rmd格式的文件时， RStudio 的界面发生了一些变化（多了一些按钮），如下图所示。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210414130134283.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210414130134283.png)
 
 
 这里我们对界面做一些介绍，视频介绍在[这](https://mp.weixin.qq.com/s/Dl1a36omEVI1QGP0HgbuyA)。
@@ -259,7 +259,7 @@ R 代码块一般通过 ```{R}``` 来插入，插入代码段的**快捷键**：
     
     当然你也可以通过 RStudio 界面进行部分参数的设置（更加便捷）：
     
-    ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/WeChatd2107f6cf1d1088d22c97e4b3e09f344.png)
+    [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/WeChatd2107f6cf1d1088d22c97e4b3e09f344.png)
     
     具体演示可见[b站](https://www.bilibili.com/video/BV1ib4y1X7r9)视频。
 
@@ -321,14 +321,14 @@ plot(1:10)
   > 注意：图片文件放的位置（如果和 rmd 同一目录，则可以直接 xxx.png； 如果在其他位置记得加上相对路径）。
 
 
-  ![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211033682.png)
+  [图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211033682.png)
 
   - **方式二**
 
   在 source editor 情况下，直接外部拉入图形即可，会自动保存在相对文件夹的 images 中，或者点击图形按钮导入。
 
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211101185.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211101185.png)
 
 
   - **方式三**
@@ -347,11 +347,11 @@ plot(1:10)
 
 - markdown格式
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403210427161.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403210427161.png)
 
 - Typora格式
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211149020.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211149020.png)
 
 #### 2. 内部代码输出的表格
 
@@ -373,7 +373,7 @@ knitr包提供了一个 `kable()` 函数可以用来把数据框或矩阵转化�
 knitr::kable(co)
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211210045.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211210045.png)
 
 
 `kable()` 函数的 `digits=` 选项可以控制小数点后数字位数， `caption=` 选项可以指定表的标题内容。
@@ -386,7 +386,7 @@ knitr::kable(co)
 pander::pander(lmr)
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211229254.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211229254.png)
 
 但是，经过试验发现， 表中中有中文时 pander 包会出错，这里参考公众号[R 友舍](https://mp.weixin.qq.com/s/MKvRoyCyEHqHNzC9DRfVWQ)。
 
@@ -447,7 +447,7 @@ kableExtra::kable_styling(x_html,bootstrap_options = "striped",
 ```
 
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211332249.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211332249.png)
 
 > 注意：上面例子 `knitr:: kable` 制定了 `kable` 函数来自 knitr 包，目的是方式和其他包内同名函数冲突。
 
@@ -460,7 +460,7 @@ kable(head(rock), "html") %>%
                           full_width = F)
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211413207.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211413207.png)
 
 
 #### 3. 设置表格的对齐方式
@@ -473,7 +473,7 @@ kableExtra::kable_styling(x_html,bootstrap_options = "striped",
                           position = "left")
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210424173324184.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210424173324184.png)
 
 #### 4. 设置表格的字体大小
 
@@ -486,7 +486,7 @@ kableExtra::kable_styling(x_html,bootstrap_options = "striped",
                           font_size = 20
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211439668.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211439668.png)
 
 
 #### 5.设置表格的行与列
@@ -504,7 +504,7 @@ kableExtra::column_spec(x_html,1:2,
 ```
 
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211506891.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211506891.png)
 
 ```
 x_html <- knitr:: kable(head(rock), "html")
@@ -517,7 +517,7 @@ kableExtra::row_spec(x_html,1:2,
                         background = "#D7261E")
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211527153.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211527153.png)
 
 #### 6.其它表格渲染
 
@@ -547,7 +547,7 @@ kable_styling(x_html,"striped")
 ```
 
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210403211552162.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210403211552162.png)
 
 
 
@@ -588,11 +588,11 @@ rticles 软件包提供了各种期刊和出版商的模板：
 
 下载完对应的包之后，找到对应模板打开即可。输出 pdf 是需要配置 tex 环境的哦！建议安装 Tinytex， 具体安装教程见前面。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195440875.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195440875.png)
 
 编译后得到的结果，这是他模板原始的样子，如果想调整页面行间距，字体颜色等，请见下面一章。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195456780.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195456780.png)
 
 ### 4.2. rmdformats 包
 
@@ -617,13 +617,13 @@ output:
 ---
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195508990.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195508990.png)
 
 **方法二：**
 
 在你安装完该包之后你可以使用通过按钮新建该模版（其实他有很多类似的模板，我这里只展现了一种）：
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195516091.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195516091.png)
 
 > 以下模板也可以通过这种方式构建，前提是你安装了这个包，这样你就可以在 From Template 中找到该包对应的模板了。
 
@@ -641,7 +641,7 @@ output:
 ---
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195521796.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195521796.png)
 
 ### 4.4. tufte 包
 
@@ -655,7 +655,7 @@ output:
 ---
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195528253.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195528253.png)
 
 ### 4.5. cerulean 包
 
@@ -671,7 +671,7 @@ output:
 ---
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210315195535713.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210315195535713.png)
 
 
 
@@ -693,7 +693,7 @@ Markdown 语法没有用于更改文本颜色的内置方法。我们可以使�
 我是\textcolor{blue}{庄闪闪}呀！欢迎关注我的\textcolor{red}{公众号}：\textcolor{blue}{庄闪闪的R语言手册}。
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318124743606.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318124743606.png)
 
 在上面的示例中，第一组花括号包含所需的文本颜色，第二组花括号包含应将此颜色应用到的文本。
 
@@ -721,11 +721,11 @@ output:
 
 这时的页边距就变成下面这样了：
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318132951265.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318132951265.png)
 
 当然全文字体大小等操作也是这样操作的，在 geometry 操作即可：
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318123645722.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318123645722.png)
 
 ### 5.3. 缩进文本 
 
@@ -741,17 +741,17 @@ output:
 
 输出为：
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318125239921.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318125239921.png)
 
 ### 5.4.分页
 
 如果想要分页，可以使用 `\newpage`。 例如：如果想把目录和正文内容分开，可以在在正文前面加入这个代码
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210319193017798.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210319193017798.png)
 
 这时输出的结果，目录一个界面，正文另起一页。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210319193045376.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210319193045376.png)
 
 ### 5.5.控制文本输出的宽度
 
@@ -766,7 +766,7 @@ matrix(runif(100), ncol = 20)
 ​```
 ```
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318125512209.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318125512209.png)
 
 ```
 ​```{r}
@@ -776,7 +776,7 @@ matrix(runif(100), ncol = 20)
 ```
 
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318125542194.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318125542194.png)
 
 但是这种方式不一定对所有函数都适用，这是你可以使用其他方式，对于 Html （这里不做解释，主要将 pdf）， 可以参见[教程](https://bookdown.org/yihui/rmarkdown-cookbook/text-width.html "教程")。
 
@@ -802,7 +802,7 @@ output:
 
 这是输出的结果，但是其实不是很美观
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318130218480.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318130218480.png)
 
 
 
@@ -866,17 +866,17 @@ if (TRUE) {
 
 输出结果为：
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210318131400399.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210318131400399.png)
 
 ### 5.9.多列输出
 
 这个特别好用！虽然学起来有那么一点困难，具体我再出一期推文，把这个讲清楚。具体可以见这里的[教程](https://bookdown.org/yihui/rmarkdown-cookbook/multi-column.html "教程")。类似于排版成这种形式：
   
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/image-20210319195033178.png)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/image-20210319195033178.png)
 
 
 ## 小编有话说
 
 - 当然 R Markdown 还可以做各种拓展，比如 presentation（ioslides、 Beamer、 slidy、 PowerPoint），Documents（Html、 Notebook、 PDF、 word） 及其他拓展 （Dashboards、Tufte Handouts、 xaringan Presentations、 Websites） 等。有部分我已经整理好了，可以在下面窗口的拓展教程中找到。
 
-![](https://gitee.com/zhuang_liang_liang0825/other/raw/master/9601618034106_.pic_hd.jpg)
+[图片](https://gitee.com/zhuang_liang_liang0825/other/blob/master/9601618034106_.pic_hd.jpg)


### PR DESCRIPTION
相关问题：https://github.com/cosname/cosx.org/issues/1020

使用的命令：

```
sed -i -r 's/!(\[.+\]\(.+gitee.+)raw(.+\))/\1blob\2/g' content/post/2018-01-17-build-blog-with-blogdown-hugo-netlify-github.md
sed -i -r 's/!\[\](\(.+gitee.+)raw(.+\))/[图片]\1blob\2/g' content/post/2021-04-10-rmarkdown-introduction.md
sed -i -r 's/!(\[.+\]\(.+gitee.+)raw(.+\))/\1blob\2/g' content/post/2021-03-07-build-blog-step-by-step.md
```