### PR TITLE
跟进 #995 添加作者文章列表 解决重名问题

### DIFF
--- a/layouts/shortcodes/members.html
+++ b/layouts/shortcodes/members.html
@@ -1,7 +1,42 @@
 <table class="profile">
-<tbody>
-{{ range $.Site.Data.members.list }}
-<tr><td><h3>{{ .name }}</h3>{{ .intro | markdownify }}</td><td><img src="{{ .image }}" alt="{{ .name }}"/></td></tr>
-{{ end }}
-</tbody>
+    <tbody>
+        {{ range $.Site.Data.members.list }}
+	        {{ $.Scratch.Set "member_author_id" .author_id}}
+        <tr>
+            <td>
+                <h3>{{ .name }}</h3>{{ .intro | markdownify }}
+            </td>
+            <td><img src="{{ .image }}" alt="{{ .name }}" /></td>
+        </tr>
+        <tr>
+            <td>
+
+                {{ if .id }}
+                    {{ $pages := (where $.Site.RegularPages ".Params.author_id" "intersect" (slice .id)) }}
+                    {{ $pages := $pages | union (where $.Site.RegularPages ".Params.author_id" .id) }}
+                    {{ range (where $pages "Section" "!=" "") }}
+                    <li>
+                        <span class="date">{{ .Date.Format "2006/01/02" }}</span>
+                        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                        <span>{{ .Params.author }}</span>
+                    </li>                 
+                    {{ end }}      
+                {{ else }}
+                {{ $pages := (where $.Site.RegularPages ".Params.author" "intersect" (slice .name)) }}
+                {{ $pages := $pages | union (where $.Site.RegularPages ".Params.author" .name) }}
+                    {{ range (where $pages "Section" "!=" "") }}
+                    <li>
+                        <span class="date">{{ .Date.Format "2006/01/02" }}</span>
+                        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                        <span>{{ .Params.author }}</span>
+                    </li>                 
+                    {{ end }}                
+                {{ end }}
+                <ul>
+
+                </ul>
+            </td>
+        </tr>
+        {{ end }}
+    </tbody>
 </table>

--- a/layouts/shortcodes/members.html
+++ b/layouts/shortcodes/members.html
@@ -1,7 +1,6 @@
 <table class="profile">
     <tbody>
         {{ range $.Site.Data.members.list }}
-	        {{ $.Scratch.Set "member_author_id" .author_id}}
         <tr>
             <td>
                 <h3>{{ .name }}</h3>{{ .intro | markdownify }}
@@ -10,20 +9,21 @@
         </tr>
         <tr>
             <td>
-
                 {{ if .id }}
                     {{ $pages := (where $.Site.RegularPages ".Params.author_id" "intersect" (slice .id)) }}
                     {{ $pages := $pages | union (where $.Site.RegularPages ".Params.author_id" .id) }}
+                    {{ $pages := $pages | union (where (where $.Site.RegularPages ".Params.author_id" "==" nil ) ".Params.author" "intersect" (slice .name )) }}
+                    {{ $pages := $pages | union (where (where $.Site.RegularPages ".Params.author_id" "==" nil ) ".Params.author" .name ) }}
                     {{ range (where $pages "Section" "!=" "") }}
                     <li>
                         <span class="date">{{ .Date.Format "2006/01/02" }}</span>
                         <a href="{{ .RelPermalink }}">{{ .Title }}</a>
                         <span>{{ .Params.author }}</span>
                     </li>                 
-                    {{ end }}      
+                    {{ end }}
                 {{ else }}
-                {{ $pages := (where $.Site.RegularPages ".Params.author" "intersect" (slice .name)) }}
-                {{ $pages := $pages | union (where $.Site.RegularPages ".Params.author" .name) }}
+                    {{ $pages := (where $.Site.RegularPages ".Params.author" "intersect" (slice .name )) }}
+                    {{ $pages := $pages | union ( where $.Site.RegularPages ".Params.author" .name ) }}
                     {{ range (where $pages "Section" "!=" "") }}
                     <li>
                         <span class="date">{{ .Date.Format "2006/01/02" }}</span>
@@ -31,9 +31,8 @@
                         <span>{{ .Params.author }}</span>
                     </li>                 
                     {{ end }}                
-                {{ end }}
+                {{ end }} 
                 <ul>
-
                 </ul>
             </td>
         </tr>


### PR DESCRIPTION
由于@CyrusYip 的  #995 年代久远所以重新起草一个pr 


在 https://github.com/cosname/cosx.org/pull/995#issuecomment-981090572 里的代码因为空集与空集取intersect 为true,  导致 **memberlist里没有author_id, 文章也没有设置author_id的文章全被放在一起**

由于#950 https://github.com/cosname/cosx.org/pull/950#discussion_r658064504 的历史原因，没有重名的小伙伴就没有设置id, 导致这里的代码逻辑判断有点复杂:

1. 如果member list (`data/members.yaml`) 设置了id: 
    a. 如果文章设置了author_id, 则按id匹配
    b. 如果文章没有设置author_id, 则按姓名匹配
3. 如果member list 没有设置 id : 直接按姓名匹配

不过这个代码还有些不优雅的地方需要改进，主要是单一作者还是多个作者的文章需要两行代码觉得有点不爽…


效果:

1. 两位赵鹏的文章列表正常

![微信图片_20230410194309](https://user-images.githubusercontent.com/19829201/230895299-65b00707-d43a-48be-96e6-2ae864e2acdf.png)

2. member.yaml有author_id ，但大部分没设置author_id的旧文章也正常的yihui:

![微信图片_20230410194257](https://user-images.githubusercontent.com/19829201/230895286-a4b46c6d-cd37-4e78-8ddc-766671fc910d.png)


