### PR TITLE
给作者加上 id，用于定位作者介绍与文章

### DIFF
--- a/layouts/shortcodes/members.html
+++ b/layouts/shortcodes/members.html
@@ -3,7 +3,11 @@
         {{ range $.Site.Data.members.list }}
         <tr>
             <td>
-                <h3 id="{{ anchorize .name }}">{{ .name }}</h3>{{ .intro | markdownify }}
+                {{ if .id }}
+                  <h3 id="{{ anchorize .id }}">{{ .name }}</h3>{{ .intro | markdownify }}
+                {{ else }}
+                  <h3 id="{{ anchorize .name }}">{{ .name }}</h3>{{ .intro | markdownify }}
+                {{ end }}
             </td>
             <td><img src="{{ .image }}" alt="{{ .name }}" /></td>
         </tr>

--- a/layouts/shortcodes/members.html
+++ b/layouts/shortcodes/members.html
@@ -3,7 +3,7 @@
         {{ range $.Site.Data.members.list }}
         <tr>
             <td>
-                <h3>{{ .name }}</h3>{{ .intro | markdownify }}
+                <h3 id="{{ anchorize .name }}">{{ .name }}</h3>{{ .intro | markdownify }}
             </td>
             <td><img src="{{ .image }}" alt="{{ .name }}" /></td>
         </tr>

--- a/layouts/shortcodes/members.html
+++ b/layouts/shortcodes/members.html
@@ -3,11 +3,7 @@
         {{ range $.Site.Data.members.list }}
         <tr>
             <td>
-                {{ if .id }}
-                  <h3 id="{{ anchorize .id }}">{{ .name }}</h3>{{ .intro | markdownify }}
-                {{ else }}
-                  <h3 id="{{ anchorize .name }}">{{ .name }}</h3>{{ .intro | markdownify }}
-                {{ end }}
+                  <h3 id="{{ default .name .id | anchorize }}">{{ .name }}</h3>{{ .intro | markdownify }}
             </td>
             <td><img src="{{ .image }}" alt="{{ .name }}" /></td>
         </tr>

--- a/layouts/shortcodes/members.html
+++ b/layouts/shortcodes/members.html
@@ -3,7 +3,7 @@
         {{ range $.Site.Data.members.list }}
         <tr>
             <td>
-                  <h3 id="{{ default .name .id | anchorize }}">{{ .name }}</h3>{{ .intro | markdownify }}
+                <h3 id="{{ default .name .id | anchorize }}">{{ .name }}</h3>{{ .intro | markdownify }}
             </td>
             <td><img src="{{ .image }}" alt="{{ .name }}" /></td>
         </tr>


### PR DESCRIPTION
统计之都以前有这样的 URL 记录某位作者的文章：https://cosx.org/author/yihui/ 。添加 HTML id 的可以实现此功能。相关讨论：https://github.com/yihui/yihui.org/pull/139 。代码是在这里抄的：https://github.com/yihui/yihui.org/pull/139#issuecomment-1536567043 ，感谢 @yihui 。我这边装不上 blogdown，直接用 hugo v0.111.3+extended 测试的。

---

中文名、带空格的英文名、同名作者都没问题。

示例：

- http://localhost:1313/members/#cynthia-chen
- http://localhost:1313/members/#%E8%B0%A2%E7%9B%8A%E8%BE%89
- http://localhost:1313/members/#zhaopeng
- http://localhost:1313/members/#pzhaonet

~~已知问题：两位赵鹏仍公用 id，只能定位到第一位（已解决）。~~

~~- http://localhost:1313/members/#%E8%B5%B5%E9%B9%8F~~